### PR TITLE
fix: StableBlock responds to theme changes

### DIFF
--- a/packages/streamdown-rn/src/renderers/StableBlock.tsx
+++ b/packages/streamdown-rn/src/renderers/StableBlock.tsx
@@ -49,8 +49,10 @@ export const StableBlock: React.FC<StableBlockProps> = React.memo(
     console.warn('StableBlock has no AST:', block.type, block.id);
     return null;
   },
-  // Only re-render if the block's content hash changes (which shouldn't happen for stable blocks)
-  (prev, next) => prev.block.contentHash === next.block.contentHash
+  // Re-render if block content or theme changes
+  (prev, next) =>
+    prev.block.contentHash === next.block.contentHash &&
+    prev.theme === next.theme
 );
 
 StableBlock.displayName = 'StableBlock';


### PR DESCRIPTION
Previously StableBlock memo comparison only checked contentHash,
causing text colors to not update when switching dark/light mode.